### PR TITLE
Fix chance of server crashing in cases where leader is null

### DIFF
--- a/src/main/java/com/dragn0007/dragnlivestock/entities/cow/OCow.java
+++ b/src/main/java/com/dragn0007/dragnlivestock/entities/cow/OCow.java
@@ -148,8 +148,10 @@ public class OCow extends Animal implements IAnimatable {
 	}
 
 	public void stopFollowing() {
-		this.leader.removeFollower();
-		this.leader = null;
+		if (this.leader != null) {
+			this.leader.removeFollower();
+			this.leader = null;
+		}
 	}
 
 	public void addFollower() {


### PR DESCRIPTION
Had this happen twice, likely due to CarryOn or some other reason, to cause `this.leader` in OCow (Maybe more, only know of this one) to become `null`